### PR TITLE
Avoid Error on rules array

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,12 @@ return [
             'as access' => [
                 'class' => yii\filters\AccessControl::className(),
                 'rules' => [
-                    'controllers'   => ['i18n/default'],
-                    'actions'       => ['index', 'save', 'update', 'rescan', 'clear-cache', 'delete', 'restore'],
-                    'allow'         => true,
-                    'roles'         => ['translator'],
+                    [
+                        'controllers'   => ['i18n/default'],
+                        'actions'       => ['index', 'save', 'update', 'rescan', 'clear-cache', 'delete', 'restore'],
+                        'allow'         => true,
+                        'roles'         => ['translator'],
+                    ]
                 ],
             ],
         ],


### PR DESCRIPTION
Correct 'as access' array tor avoid error: Setting unknown property: yii\filters\AccessRule::0