### PR TITLE
Yii::$app->i18n->languages can now be a callable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ return [
         'i18n' => [
             'class'      => uran1980\yii\modules\i18n\components\I18N::className(),
             'languages'  => ['en', 'de', 'fr', 'it', 'es', 'pt', 'ru'],
+            // Or, if you manage languages in database
+            //'languages'  => function() {
+            //    /* /!\ Make sure the result is a mere list of language codes */
+            //    return \namespace\of\your\LanguageClass::find()->select('code')->column();
+            //},
             'format'     => 'db',
             'sourcePath' => [
                 __DIR__ . '/../../frontend',

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "uran1980/yii2-translate-panel",
     "description": "Yii2 Translate Panel makes the translation of your application awesome!",
-    "version": "0.1.25",
+    "version": "0.1.26",
     "type": "yii2-extension",
     "keywords": [
         "yii2",

--- a/views/default/_message-tabs.php
+++ b/views/default/_message-tabs.php
@@ -4,9 +4,14 @@ use yii\helpers\Html;
 use yii\bootstrap\Tabs;
 
 $items = [];
-foreach ( Yii::$app->i18n->languages as $lang ) {
+if (is_callable(Yii::$app->i18n->languages)) {
+    $languages = call_user_func(Yii::$app->i18n->languages);
+} else {
+    $languages = Yii::$app->i18n->languages;
+}
+foreach ( $languages as $lang ) {
     $message = Yii::t($model->category, $model->message, [], $lang);
-    $message = ($model->message == $message && $lang != Yii::$app->i18n->languages[0])
+    $message = ($model->message == $message && $lang != $languages[0])
              ? '' : $message;
     $items[] = [
         'label' => '<b>' . strtoupper($lang) . '</b>',


### PR DESCRIPTION
I believe it is common for end-users to extend or restrain the list of languages a website provides. Therefore, they can manage it in back-office. But we no longer can use a plain array in the configuration file.

This provide the possibility to have a DB-managed list of languages and retrieve it with an ActiveQuery result, with a callable in configuration file.