### PR TITLE
Handles Yii's i18n forceTranslation parameter globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ return [
             'languages'  => ['en', 'de', 'fr', 'it', 'es', 'pt', 'ru'],
             // Or, if you manage languages in database
             //'languages'  => function() {
-            //    /* /!\ Make sure the result is a mere list of language codes */
-            //    return \namespace\of\your\LanguageClass::find()->select('code')->column();
+            //    /* /!\ Make sure the result is a mere list of language codes, and the
+            //     * one used in views is the first one */
+            //    return \namespace\of\your\LanguageClass::find()->where(['active' => true'])->orderBy('default' => SORT_DESC])->select('code')->column();
             //},
             'format'     => 'db',
             'sourcePath' => [
@@ -63,11 +64,20 @@ return [
                 __DIR__ . '/../../common',
             ],
             'messagePath' => __DIR__  . '/../../messages',
+            // Whether database messages are to be used instead of view ones.
+            // Enables editing messages in locale specified by
+            // Yii::$app->sourceLanguage
+            // Can be set per translation category too
+            //'forceTranslation' => true,
             'translations' => [
                 '*' => [
                     'class'           => yii\i18n\DbMessageSource::className(),
                     'enableCaching'   => true,
                     'cachingDuration' => 60 * 60 * 2, // cache on 2 hours
+                    // Whether database messages are to be used instead of view
+                    // ones. Enables editing messages in view code locale.
+                    // Can be set globally too.
+                    //'forceTranslation' => true,
                 ],
             ],
         ],

--- a/components/I18N.php
+++ b/components/I18N.php
@@ -2,6 +2,8 @@
 
 namespace uran1980\yii\modules\i18n\components;
 
+use \yii\i18n\DbMessageSource;
+
 class I18N extends \Zelenin\yii\modules\I18n\components\I18N
 {
     /**
@@ -21,6 +23,17 @@ class I18N extends \Zelenin\yii\modules\I18n\components\I18N
      * @var string
      */
     public $translator = 'Yii::t';
+
+    /**
+     * boolean, whether to force translation or not.
+     * Defaults to false.In that case, the source message will be displayed as in
+     * the code instead of what you could have set in database. When set to true,
+     * the version in database will be used instead of the code one, and you will
+     * be able to edit the messages for the sourceLanguage locale
+     *
+     * @var boolean
+     */
+    public $forceTranslation = false;
 
     /**
      * boolean, whether to sort messages by keys when merging new messages
@@ -130,6 +143,29 @@ class I18N extends \Zelenin\yii\modules\I18n\components\I18N
         }
         if (!is_array($this->languages)) {
             throw new InvalidConfigException('i18n component [language] must be an array or a callable returning an array');
+        }
+        if (!is_bool($this->forceTranslation)) {
+            throw new InvalidConfigException('i18n component [forceTranslation] must be a boolean');
+        }
+        if (!empty($this->sourceLanguage) && !is_string($this->sourceLanguage)) {
+            throw new InvalidConfigException('i18n component [sourceLanguage] must be a non-empty string');
+        }
+
+        $translationDefaultParams = [
+            'class' => DbMessageSource::className(),
+            'sourceMessageTable' => $this->sourceMessageTable,
+            'messageTable' => $this->messageTable,
+            'on missingTranslation' => $this->missingTranslationHandler
+        ];
+        if ($this->forceTranslation) {
+            $translationDefaultParams['forceTranslation'] = true;
+        }
+
+        if (!isset($this->translations['*'])) {
+            $this->translations['*'] = $translationDefaultParams;
+        }
+        if (!isset($this->translations['app']) && !isset($this->translations['app*'])) {
+            $this->translations['app'] = $translationDefaultParams;
         }
 
         parent::init();

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name" : "uran1980/yii2-translate-panel",
 	"description" : "Yii2 Translate Panel makes the translation of your application awesome!",
-	"version" : "0.1.29",
+	"version" : "0.1.30",
 	"type" : "yii2-extension",
 	"keywords" : [
 		"yii2",

--- a/config/messages.php
+++ b/config/messages.php
@@ -6,6 +6,12 @@ return [
     // array, required, list of language codes that the extracted messages
     // should be translated to. For example, ['zh-CN', 'de'].
     'languages' => ['en', 'de', 'fr', 'it', 'es', 'pt', 'ru'],
+    // boolean, whether to force translation or not.
+    // Defaults to false. In that case, the source message will be displayed as in
+    // the code instead of what you could have set in database. When set to true,
+    // the version in database will be used instead of the code one, and you will
+    // be able to edit the messages for the sourceLanguage locale
+    'forceTranslation' => false,
     // string, the name of the function for translating messages.
     // Defaults to 'Yii::t'. This is used as a mark to find the messages to be
     // translated. You may use a string for single function name or an array for

--- a/views/default/_message-tabs.php
+++ b/views/default/_message-tabs.php
@@ -8,17 +8,22 @@ $items = [];
 $languages = Yii::$app->i18n->languages;
 foreach ( $languages as $lang ) {
     $message = Yii::t($model->category, $model->message, [], $lang);
-    $message = ($model->message == $message && $lang != $languages[0])
-             ? '' : $message;
+    $message = ($model->message == $message && Yii::$app->sourceLanguage == $lang)
+        ? $model->message : $message;
+    $parameters = [
+        'id'    => 'message-' . $lang . '-translation',
+        'class' => 'translation-textarea form-control',
+        'rel'   => $lang,
+        'dir'   => (in_array($lang, ['ar', 'fa']) ? 'rtl' : 'ltr'),
+        'rows'  => 3,
+    ];
+    if (!Yii::$app->i18n->translations[$model->category]->forceTranslation && Yii::$app->sourceLanguage == $lang) {
+        $parameters['disabled'] = 'disabled';
+        $parameters['title']    = Module::t('Please set [forceTranslation] to true to be able to edit this field');
+    }
     $items[] = [
         'label' => '<b>' . strtoupper($lang) . '</b>',
-        'content' => Html::textarea('Message[' . $lang . '][translation]', $message, [
-            'id'    => 'message-' . $lang . '-translation',
-            'class' => 'translation-textarea form-control',
-            'rel'   => $lang,
-            'dir'   => (in_array($lang, ['ar', 'fa']) ? 'rtl' : 'ltr'),
-            'rows'  => 3,
-        ]) . Html::hiddenInput('categories[' . $lang . ']', $model->category),
+        'content' => Html::textarea('Message[' . $lang . '][translation]', $message, $parameters) . Html::hiddenInput('categories[' . $lang . ']', $model->category),
         'active' => ($lang == Yii::$app->language) ? true : false,
     ];
 }

--- a/views/default/update.php
+++ b/views/default/update.php
@@ -24,9 +24,16 @@ $this->params['breadcrumbs'][] = $this->title;
         </div>
         <?php $form = ActiveForm::begin(); ?>
         <div class="row">
-            <?php foreach ($model->messages as $language => $message) : ?>
-                <?php echo $form->field($model->messages[$language], '[' . $language . ']translation', ['options' => ['class' => 'form-group col-sm-6']])->textInput()->label(strtoupper($language)); ?>
-            <?php endforeach; ?>
+            <?php foreach ($model->messages as $language => $message):
+            $message->translation = ($model->message == $message && Yii::$app->sourceLanguage == $lang
+                ? $model->message : $message->translation);
+            echo $form->field($message, '[' . $language . ']translation', ['options' => ['class' => 'form-group col-sm-6']])
+                    ->textInput(
+                        (!Yii::$app->i18n->translations[$model->category]['forceTranslation'] && Yii::$app->sourceLanguage == $language)
+                            ? ['disabled' => 'disabled', 'title' => Module::t('Please set [forceTranslation] to true to be able to edit this field')]
+                            : []
+                    )->label(strtoupper($language));
+            endforeach; ?>
         </div>
         <div class="form-group">
             <?php echo


### PR DESCRIPTION
This allows to force translation on all categories in one parameter. Defaults to `false` in order not to cause BC breaks.

Now when the translation is not forced, the field in source language (based on `Yii::$app->sourceLanguage`) will be disabled, and display the source message. Only when the [forceTranslation] parameter is set will this field be editable, and the translation for source language displayed.