### PR TITLE
Fix runtime error

### DIFF
--- a/models/search/SourceMessageSearch.php
+++ b/models/search/SourceMessageSearch.php
@@ -496,12 +496,10 @@ class SourceMessageSearch extends SourceMessage
         }
 
         // ------------------------------ COUNTER ------------------------------
-        $counter = ['new' => 0, 'obsolete' => 0];
+        $counter = ['new' => 0, 'obsolete' => count($obsolete)];
         foreach ( $new as $msgs ) {
             $counter['new'] += count($msgs);
         }
-        
-        $counter['obsolete'] += count($obsolete);
 
         return $counter;
     }

--- a/models/search/SourceMessageSearch.php
+++ b/models/search/SourceMessageSearch.php
@@ -500,9 +500,8 @@ class SourceMessageSearch extends SourceMessage
         foreach ( $new as $msgs ) {
             $counter['new'] += count($msgs);
         }
-        foreach ( $obsolete as $msgs ) {
-            $counter['obsolete'] += count($msgs);
-        }
+        
+        $counter['obsolete'] += count($obsolete);
 
         return $counter;
     }


### PR DESCRIPTION
Hi, thanks for great tool for translation! 

I've got an error. This pull request should fix the issue. According to [the line](https://github.com/uran1980/yii2-translate-panel/blob/master/models/search/SourceMessageSearch.php#L434) `$obsolete` contains IDs, not strings. So it is not possible to use `count(..)` like you did.